### PR TITLE
database set by the class extending DBTemplate always gets overridden

### DIFF
--- a/lib/dbtemplate.php
+++ b/lib/dbtemplate.php
@@ -68,9 +68,6 @@ class DbTemplate extends Form {
 
         $this->db_link = $db_link;
 
-        $this->database = $this->db_link->getDatabase();
-
-
         // Pull the cache if available
         $cache = $this->Cache('get', 'table_' . $this->table . '.cache.php', '', '1 day');
 

--- a/lib/dbtemplate.php
+++ b/lib/dbtemplate.php
@@ -52,8 +52,10 @@ class DbTemplate extends Form {
      * @var string
      */
     private $group_by;
-
-    private $db_link;
+    /**
+     * @var \Simpl\DB
+     */
+    protected $db_link;
 
     /**
      * DbTemplate Constructor


### PR DESCRIPTION
From what I can see $this->db_link->getDatabase() will always return the database set by DB_DEFAULT

If the class extending DbTemplate sets it's public variable to be any database either within __construct ($this->database = 'database') or as a class member (public $database = 'database')

The return for $this->db_link->getDatabase() will always be the initial DB_DEFAULT