### PR TITLE
Conditions no longer doubled up for base cases in GetList()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "phpsimpl/simpl",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "type": "library",
     "description": "PHPSimpl - a collection of useful PHP classes",
     "keywords": [

--- a/lib/dbtemplate.php
+++ b/lib/dbtemplate.php
@@ -438,10 +438,10 @@ class DbTemplate extends Form {
         		$search .= ($class->search != '')?'`' . $class->database . '`.`' . $class->table . '`.' . $name . ' ' . (($class->Get('type',$name) == 'string' || $class->Get('type',$name) == 'blob')?'LIKE \'%' . $this->db_link->Prepare($class->search) . '%\'':' = \'' . $this->db_link->Prepare($class->search) . '\'') . ' OR ':'';
         	}
 
-                // If there are conditions on the joined class tack them on to the current class conditions
-                if ($class->conditions != ''){
-                    $this->conditions .= (($this->conditions != '')?' AND ':'') . $class->conditions;
-                }
+            // If there are conditions on the joined class tack them on to the current class conditions
+            if ($class->conditions != '' && $class->conditions != $this->conditions) {
+                $this->conditions .= (($this->conditions != '')?' AND ':'') . $class->conditions;
+            }
 
         	// Create the return fields
         	if (isset($returns[$key]) && is_array($returns[$key]) && count($returns[$key]) > 0){


### PR DESCRIPTION
Check for equal conditions before applying the same condition to the query.